### PR TITLE
Rename variable otherwise undefined

### DIFF
--- a/src/finetuning_data.py
+++ b/src/finetuning_data.py
@@ -44,7 +44,7 @@ class Dataset(torch.utils.data.Dataset):
                 negatives += random_negatives
             if n_hard_negatives > 0:
                 hard_negatives = random.sample(
-                    example["hard_negative_ctxs"][self.hard_negative_min_idx :], n_hard_negatives
+                    example["hard_negative_ctxs"][self.negative_hard_min_idx :], n_hard_negatives
                 )
                 negatives += hard_negatives
         else:


### PR DESCRIPTION
This is a minor bugfix.
Otherwise it becomes impossible to provide _negative_hard_ratio_ via the cmdline.

Thanks for the great repository!

